### PR TITLE
Call getAndVerifyPackage() in shared classes patch

### DIFF
--- a/src/java.base/share/classes/java/net/URLClassLoader.java
+++ b/src/java.base/share/classes/java/net/URLClassLoader.java
@@ -699,25 +699,7 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
        if (i != -1) {                                                          //IBM-shared_classes_misc
            String pkgname = name.substring(0, i);                              //IBM-shared_classes_misc
            // Check if package already loaded.                                 //IBM-shared_classes_misc
-           Package pkg = getPackage(pkgname);                                  //IBM-shared_classes_misc
-            if (pkg != null) {                                                  //IBM-shared_classes_misc
-               // Package found, so check package sealing.                     //IBM-shared_classes_misc
-               if (pkg.isSealed()) {                                           //IBM-shared_classes_misc
-                   // Verify that code source URL is the same.                 //IBM-shared_classes_misc
-                   if (!pkg.isSealed(url)) {                                   //IBM-shared_classes_misc
-                       throw new SecurityException(                            //IBM-shared_classes_misc
-                           "sealing violation: package " + pkgname + " is sealed"); //IBM-shared_classes_misc
-                   }                                                           //IBM-shared_classes_misc
-               } else {                                                        //IBM-shared_classes_misc
-                   // Make sure we are not attempting to seal the package      //IBM-shared_classes_misc
-                   // at this code source URL.                                 //IBM-shared_classes_misc
-                   if ((man != null) && isSealed(pkgname, man)) {              //IBM-shared_classes_misc
-                       throw new SecurityException(                            //IBM-shared_classes_misc
-                           "sealing violation: can't seal package " + pkgname +  //IBM-shared_classes_misc
-                           ": already loaded");                                //IBM-shared_classes_misc
-                   }                                                           //IBM-shared_classes_misc
-               }                                                               //IBM-shared_classes_misc
-           } else {                                                            //IBM-shared_classes_misc
+           if (getAndVerifyPackage(pkgname, man, url) == null) {               //IBM-shared_classes_misc
                try {                                                           //IBM-shared_classes_misc
                    if (null != man) {                                          //IBM-shared_classes_misc
                       definePackage(pkgname, man, url);                        //IBM-shared_classes_misc


### PR DESCRIPTION
Shared classes should call getAndVerifyPackage() instead of deprecated
getPackage()

Fixes: eclipse/openj9#4113

Signed-off-by: hangshao <hangshao@ca.ibm.com>