### PR TITLE
Only run 'java -version' if not cross compiling

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -43,10 +43,12 @@ j9vm-build : buildtools-langtools
 
 test-image : test-image-openj9
 
+# If not cross-compiling, capture 'java -version' output.
 test-image-openj9 : exploded-image
 	+$(OPENJ9_MAKE) openj9_test_image
-	# create file with build information in native libraries folder to identify which build the libraries belong to
+ifneq ($(COMPILE_TYPE), cross)
 	$(JDK_OUTPUTDIR)/bin/java -version > $(TEST_IMAGE_DIR)/openj9/java-version.txt 2>&1
+endif
 
 ALL_TARGETS += test-image-openj9
 


### PR DESCRIPTION
A replay of https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/134 for Java 12.