### PR TITLE
Revert "Add dependency in Main.mk to support the generation of jvmti.h"

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -41,9 +41,9 @@ OPENSSL_MAKE := $(MAKE) -f $(TOPDIR)/closed/openssl.gmk SPEC=$(SPEC)
 openssl-build : buildtools-langtools
 	+$(OPENSSL_MAKE)
 
-java.base-copy : j9vm-build
+java.base-copy : openssl-build
 
-java.base-libs : java.base-copy
+java.base-libs : java.base-copy j9vm-build
 
 j9vm-build : openssl-build
 	+$(OPENJ9_MAKE) openj9_build_jdk

--- a/closed/make/copy/Copy-java.base.gmk
+++ b/closed/make/copy/Copy-java.base.gmk
@@ -23,7 +23,7 @@ TARGETS += \
 	$(INCLUDE_TARGET_DIR)/ibmjvmti.h \
 	#
 
-$(INCLUDE_TARGET_DIR)/jvmti.h : $(OUTPUTDIR)/vm/include/jvmti.h
+$(INCLUDE_TARGET_DIR)/jvmti.h : $(TOPDIR)/openj9/runtime/include/jvmti.h
 	$(call install-file)
 
 $(INCLUDE_TARGET_DIR)/ibmjvmti.h : $(TOPDIR)/openj9/runtime/include/ibmjvmti.h


### PR DESCRIPTION
Reverts ibmruntimes/openj9-openjdk-jdk12#30

We started failing to build osx.
```
17:49:45  /Users/jenkins/workspace/PullRequest-Compile-JDK12-osx_x86-64_cmprssptrs-OpenJDK12/src/java.desktop/macosx/classes/sun/lwawt/macosx/CWarningWindow.java:72: error: cannot find symbol
17:49:45                  icons[0][0] = new IconInfo(sun.awt.AWTIcon32_security_icon_bw16_png.security_icon_bw16_png);
17:49:45                                                    ^
17:49:45    symbol:   class AWTIcon32_security_icon_bw16_png
17:49:45    location: package sun.awt
17:49:45  /Users/jenkins/workspace/PullRequest-Compile-JDK12-osx_x86-64_cmprssptrs-OpenJDK12/src/java.desktop/macosx/classes/sun/lwawt/macosx/CWarningWindow.java:73: error: cannot find symbol
```