### PR TITLE
Use 'tee' for visibility of 'java -version' failures

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -54,7 +54,7 @@ test-image : test-image-openj9
 test-image-openj9 : exploded-image
 	+$(OPENJ9_MAKE) openj9_test_image
 ifneq ($(COMPILE_TYPE), cross)
-	$(JDK_OUTPUTDIR)/bin/java -version > $(TEST_IMAGE_DIR)/openj9/java-version.txt 2>&1
+	$(JDK_OUTPUTDIR)/bin/java -version 2>&1 | $(TEE) $(TEST_IMAGE_DIR)/openj9/java-version.txt
 endif
 
 ALL_TARGETS += test-image-openj9


### PR DESCRIPTION
A replay of ibmruntimes/openj9-openjdk-jdk8#281 for Java 12.