### PR TITLE
Create thread in SystemThreadGroup and not inherit ThreadLocals

### DIFF
--- a/closed/src/java.base/share/classes/java/io/ClassCache.java
+++ b/closed/src/java.base/share/classes/java/io/ClassCache.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
  * ===========================================================================
  * 
  * This code is free software; you can redistribute it and/or modify it
@@ -209,25 +209,24 @@ final class ClassCache {
         }
 
         public Thread run() {
-            return new Reaper(cache, queue);
+            Reaper reaper = new Reaper(cache, queue);
+            return com.ibm.oti.vm.VM.getVMLangAccess().createThread(reaper, "ClassCache Reaper", true, false, true, null);
         }
     }
 
-    private static final class Reaper extends Thread {
+    private static final class Reaper implements Runnable {
         private final WeakReference<ClassCache> cacheRef;
         private final ReferenceQueue<Object> queue;
 
         Reaper(ClassCache cache, ReferenceQueue<Object> queue) {
-            super("ClassCache Reaper");
             this.queue = queue;
             cacheRef = new WeakReference<ClassCache>(cache, queue);
-            setDaemon(true);
-            setContextClassLoader(null);
         }
-/*
- * Blocks on remove() on queur reference and calls processStaleRef() when any loader is removed.(non-Javadoc)
- * @see java.lang.Thread#run()
- */
+
+        /*
+         * Blocks on remove() on queur reference and calls processStaleRef() when any loader is removed.(non-Javadoc)
+         * @see java.lang.Thread#run()
+         */
         public void run() {
             Object staleRef = null;
             do {


### PR DESCRIPTION
Create thread in `SystemThreadGroup` and not inherit `ThreadLocals`

Created the thread via `com.ibm.oti.vm.VM.getVMLangAccess().createThread()`.
This thread is expected to be alive along with `JVM` hence belongs to the system thread group.
This thread doesn't need inherit `ThreadLocals` and avoid copying `ThreadLocals` which causes `NPE` in some use scenarios.

Note: this is the replay of https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/170.

Reviewer: @pshipton 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>