### PR TITLE
Disable openssl native crypto for MessageDigest

### DIFF
--- a/src/java.base/share/classes/sun/security/provider/SunEntries.java
+++ b/src/java.base/share/classes/sun/security/provider/SunEntries.java
@@ -85,12 +85,13 @@ public final class SunEntries {
 
     /*
      * Check whether native crypto is enabled with property.
-     * By default, the native crypto is enabled  and uses native library crypto.
-     * The property 'jdk.nativeDigest' is used to disable Native digest alone
-     * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
+     * By default, the native crypto is enabled and uses native library crypto.
+     * The native crypto for MessageDigest is disabled until
+     * https://github.com/eclipse/openj9/issues/5611 can be resolved.
+     * The property 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
      * CBC, GCM, and RSA).
      */
-    private static boolean useNativeDigest = true;
+    private static boolean useNativeDigest = false;
 
     // create an aliases List from the specified aliases
     public static List<String> createAliases(String ... aliases) {


### PR DESCRIPTION
Avoid problems such as eclipse/openj9#5611

Doc issue eclipse/openj9-docs#294

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>